### PR TITLE
Increase timeout duration of each process step

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "gitbucket-backup-plugin"
 organization := "io.github.gitbucket"
-version := "1.2.0"
+version := "1.2.1-SNAPSHOT"
 scalaVersion := "2.12.7"
 gitbucketVersion := "4.29.0"
 

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -13,7 +13,8 @@ class Plugin extends gitbucket.core.plugin.Plugin with ActorService {
   override val versions: List[Version] = List(
     new Version("1.0.0"),
     new Version("1.1.0"),
-    new Version("1.2.0"))
+    new Version("1.2.0"),
+    new Version("1.2.1"))
 
   private val logger = LoggerFactory.getLogger(classOf[Plugin])
 

--- a/src/main/scala/io/github/gitbucket/backup/actor/BackupActor.scala
+++ b/src/main/scala/io/github/gitbucket/backup/actor/BackupActor.scala
@@ -31,7 +31,7 @@ class BackupActor extends Actor {
       val backupName = Directory.getBackupName
 
       val tempBackupDir = new File(gDirectory.GitBucketHome, backupName)
-      implicit val timeout: Timeout = Timeout(5 minutes)
+      implicit val timeout: Timeout = Timeout(30 minutes)
 
       val repos = (db ? DumpDatabase(tempBackupDir.getAbsolutePath)).mapTo[List[Clone]]
 


### PR DESCRIPTION
Increase timeout duration of each process step to prevent process timeout when GitBucket contain very large repositories.

Fix #2 